### PR TITLE
fix potential null pointer dereference found by coverity

### DIFF
--- a/src/ngx_http_array_var_module.c
+++ b/src/ngx_http_array_var_module.c
@@ -553,6 +553,9 @@ ngx_http_array_var_map(ngx_http_request_t *r, ngx_str_t *res,
     value = array->elts;
 
     array_it = ngx_http_get_indexed_variable(r, conf->array_it_index);
+    if (array_it == NULL) {
+        return NGX_ERROR;
+    }
 
     if (conf->in_place) {
         new_array = array;


### PR DESCRIPTION
```
568    dd("array var map: array size: %d", (int) array->nelts);
569
   CID 258181 (#1 of 1): Dereference null return value (NULL_RETURNS)7. dereference: Dereferencing array_it, which is known to be NULL.
570    array_it->not_found = 0;
571    array_it->valid = 1;
```